### PR TITLE
Update quickstart with Apache coordinates

### DIFF
--- a/pages/quickstart.md
+++ b/pages/quickstart.md
@@ -23,21 +23,21 @@ docker run -d -p 9411:9411 openzipkin/zipkin
 
 ## Java
 
-If you have Java 8 or higher installed, the quickest way to get started is to fetch the [latest release](https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec) as a self-contained executable jar:
+If you have Java 8 or higher installed, the quickest way to get started is to fetch the [latest release](https://search.maven.org/remote_content?g=org.apache.zipkin&a=zipkin-server&v=LATEST&c=exec) as a self-contained executable jar:
 
 ~~~ bash
-curl -sSL https://zipkin.io/quickstart.sh | bash -s
+curl -sSL https://zipkin.apache.org/quickstart.sh | bash -s
 java -jar zipkin.jar
 ~~~
 
 ## Running from Source
 
-Zipkin can be run from source if you are developing new features. To achieve this, you'll need to get [Zipkin's source](https://github.com/openzipkin/zipkin) and build it.
+Zipkin can be run from source if you are developing new features. To achieve this, you'll need to get [Zipkin's source](https://github.com/apache/incubator-zipkin) and build it.
 
 ~~~ bash
 # get the latest source
-git clone https://github.com/openzipkin/zipkin
-cd zipkin
+git clone https://github.com/apache/incubator-zipkin
+cd incubator-zipkin
 # Build the server and also make its dependencies
 ./mvnw -DskipTests --also-make -pl zipkin-server clean install
 # Run the server


### PR DESCRIPTION
Note: the current instructions no longer seem to work for me; perhaps because of the domain redirect.

```bash
$ curl -sSL https://zipkin.io/quickstart.sh | bash -s
bash: line 1: syntax error near unexpected token `newline'
bash: line 1: `<!DOCTYPE html>'
```

The following updated command did work as expected.
```bash
$ curl -sSL https://zipkin.apache.org/quickstart.sh | bash -s
````