### PR TITLE
Adds sources download information for all projects except Brave

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -1,0 +1,29 @@
+- friendlyName: Zipkin Api
+  module: zipkin-api
+  version: 0.2.1
+  repo: zipkin-api
+- friendlyName: Zipkin Brave for Apache Cassandra
+  module: brave-cassandra
+  version: 0.10.2
+  repo: zipkin-brave-cassandra
+- friendlyName: Zipkin Brave for Apache Karaf
+  module: brave-karaf
+  version: 0.1.2
+  repo: zipkin-brave-karaf
+- friendlyName: Zipkin Dependencies
+  module: zipkin-dependencies
+  version: 2.2.0
+  repo: zipkin-dependencies
+- friendlyName: Zipkin Reporter Java
+  module: zipkin-reporter-java
+  version: 2.8.3
+  repo: zipkin-reporter-java
+- friendlyName: Zipkin Server and Core Library
+  module: zipkin
+  version: 2.14.0
+  repo: zipkin
+- friendlyName: Zipkin Layout Factory
+  module: zipkin-layout-factory
+  version: 0.0.5
+  repo: zipkin-layout-factory
+  type: internal

--- a/pages/downloads.md
+++ b/pages/downloads.md
@@ -1,0 +1,30 @@
+---
+title: Source Downloads
+weight: 4
+---
+
+## Source Downloads
+{% assign baseUrl = 'https://www.apache.org/dyn/closer.cgi?path=incubator/zipkin' %}
+{% assign downloads = site.data.downloads | where_exp: "download", "download.type != 'internal'" %}
+
+Apache Software Foundation (ASF) requires projects to have a downloads page, used in release announcements. Below are the locations of the official voted source releases per-project.
+
+If you like, you can [verify](https://www.apache.org/info/verification) the source downloads using Zipkin's [KEYS file](https://www.apache.org/dist/incubator/zipkin/KEYS).
+
+| Name | Version | Source | Signature | Checksum |
+|:---- |:--------|:-------|:----------|:-------- |{% for download in downloads %}{% capture zip %}{{ baseUrl }}/{{ download.module }}/{{ download.version }}/apache-{{ download.repo }}-incubating-{{ download.version }}-source-release.zip{% endcapture %}{% capture releaseNotes %}https://github.com/apache/incubator-{{ download.repo }}/releases/tag/v{{ download.version }}{% endcapture %}
+| {{ download.friendlyName }} | [{{ download.version }}]({{ releaseNotes }}) | [zip]({{ zip }}) | [asc]({{ zip }}.asc) | [sha512]({{ zip }}.sha512) |{% endfor %}
+{: .wide-table}
+
+### Internal Tools
+The following tools are not for general use, but are listed in order to comply with Apache Software Foundation (ASF) release policy.
+
+{% assign internalDownloads = site.data.downloads | where_exp: "download", "download.type == 'internal'" %}
+
+| Name | Version | Source | Signature | Checksum |
+|:---- |:--------|:-------|:----------|:-------- |{% for download in internalDownloads %}{% capture zip %}{{ baseUrl }}/{{ download.module }}/{{ download.version }}/apache-{{ download.repo }}-incubating-{{ download.version }}-source-release.zip{% endcapture %}{% capture releaseNotes %}https://github.com/apache/incubator-{{ download.repo }}/releases/tag/v{{ download.version }}{% endcapture %}
+| {{ download.friendlyName }} | [{{ download.version }}]({{ releaseNotes }}) | [zip]({{ zip }}) | [asc]({{ zip }}.asc) | [sha512]({{ zip }}.sha512) |{% endfor %}
+{: .wide-table}
+
+
+

--- a/pages/downloads.md
+++ b/pages/downloads.md
@@ -2,8 +2,6 @@
 title: Source Downloads
 weight: 4
 ---
-
-## Source Downloads
 {% assign baseUrl = 'https://www.apache.org/dyn/closer.cgi?path=incubator/zipkin' %}
 {% assign downloads = site.data.downloads | where_exp: "download", "download.type != 'internal'" %}
 


### PR DESCRIPTION
This adds download details for all releases. Brave isn't yet released,
but as this was escalated by the Secretary as urgent, we (like me)
are making this page now.

<img width="631" alt="Screen Shot 2019-06-06 at 1 16 23 PM" src="https://user-images.githubusercontent.com/64215/59008551-5de2ee00-885d-11e9-94fe-7773a20cd0d8.png">

Fixes #12

cc @apache/zipkin-committers 